### PR TITLE
🐛(circle) fix tag-based build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
           command: |
             build_arg=""
             if [[ -n "$CIRCLE_TAG" ]]; then
-              build_arg="--build-arg EP_VERSION=${CIRCLE_TAG}"
+              build_arg="--build-arg EP_VERSION=$(echo ${CIRCLE_TAG} | sed 's/^v//')"
             fi
             docker build \
               ${build_arg} \
@@ -91,7 +91,7 @@ jobs:
           command: |
             build_arg=""
             if [[ -n "$CIRCLE_TAG" ]]; then
-              build_arg="--build-arg EP_VERSION=${CIRCLE_TAG}"
+              build_arg="--build-arg EP_VERSION=$(echo ${CIRCLE_TAG} | sed 's/^v//')"
             fi
             docker build \
               ${build_arg} \


### PR DESCRIPTION
## Purpose

When using a git tag to build a particular release, the "v" prefix broke the archive download URL and thus the build.

## Proposal

- [x] fix git tag / etherpad release mapping