### PR TITLE
🔖(skin) bump to 1.8.0+education-1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.8.0+education-1.0.0] - 2020-03-30
+
+### Added
+
+- New `education` skin `1.0.0`
+
+## [1.8.0] - 2020-03-25
+
+### Added
+
+- New 1.8.0 official release
+
+[unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.8.0+education-1.0.0...HEAD
+[1.8.0+education-1.0.0]: https://github.com/openfun/etherpad-docker/compare/v1.8.0...v1.8.0+education-1.0.0
+[1.8.0]: https://github.com/openfun/etherpad-docker/releases/tag/v1.8.0

--- a/src/static/skins/education/skin.json
+++ b/src/static/skins/education/skin.json
@@ -1,0 +1,4 @@
+{
+  "name": "education",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
## Purpose

Making a new etherpad `1.8.0` release with the `1.0.0` education skin release.

## Proposal

- [x] add skin metadata file
- [x] add project CHANGELOG
