### PR TITLE
🐛(circle) fix flavored release tag pattern

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
           command: |
             build_arg=""
             if [[ -n "$CIRCLE_TAG" ]]; then
-              EP_VERSION=$(echo "${CIRCLE_TAG}" | sed -r "s/^v([0-9\.]*)\+?(\w*)-?([0-9\.]*)/\1/g")
+              EP_VERSION=$(echo "${CIRCLE_TAG}" | sed -r "s/^v([0-9\.]*)\-?(\w*)-?([0-9\.]*)/\1/g")
               build_arg="--build-arg EP_VERSION=${EP_VERSION}"
             fi
             docker build \
@@ -101,7 +101,7 @@ jobs:
           command: |
             build_arg=""
             if [[ -n "$CIRCLE_TAG" ]]; then
-              EP_VERSION=$(echo "${CIRCLE_TAG}" | sed -r "s/^v([0-9\.]*)\+?(\w*)-?([0-9\.]*)/\1/g")
+              EP_VERSION=$(echo "${CIRCLE_TAG}" | sed -r "s/^v([0-9\.]*)\-?(\w*)-?([0-9\.]*)/\1/g")
               build_arg="--build-arg EP_VERSION=${EP_VERSION}"
             fi
             docker build \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.8.0+education-1.0.0] - 2020-03-30
+## [1.8.0-education-1.0.0] - 2020-03-30
 
 ### Added
 
@@ -20,5 +20,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New 1.8.0 official release
 
 [unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.8.0+education-1.0.0...HEAD
-[1.8.0+education-1.0.0]: https://github.com/openfun/etherpad-docker/compare/v1.8.0...v1.8.0+education-1.0.0
+[1.8.0-education-1.0.0]: https://github.com/openfun/etherpad-docker/compare/v1.8.0...v1.8.0+education-1.0.0
 [1.8.0]: https://github.com/openfun/etherpad-docker/releases/tag/v1.8.0


### PR DESCRIPTION
## Purpose

The '+' sign is not allowed in docker tags, hence flavored releases should match the following pattern: x.y.z-skin-a.b.c

## Proposal

- [x] update flavored releases pattern
