### PR TITLE
🐳(project) remove custom settings from production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,11 +44,11 @@ FROM base as production
 
 WORKDIR /app
 
+# Copy the configuration file
+COPY --from=builder /builder/settings.json.docker settings.json
 # Copy sources
 COPY --from=builder /builder/src /app/src/
 COPY --from=builder /builder/node_modules /app/node_modules/
-# Copy the configuration file
-COPY settings.json settings.json
 # Copy extra static files (version.json, etc.)
 COPY src/static /app/src/static/
 COPY package.json package.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - ./private/APIKEY.txt:/app/APIKEY.txt
       # Custom plugins/skins development
       - ./src/static/skins/education:/app/src/static/skins/education
-      # Settings
+      # Mount local settings for development
       - ./settings.json:/app/settings.json
     depends_on:
       - postgresql


### PR DESCRIPTION
## Purpose

We should not enforce our settings in the final Docker image we distribute. Settings should be further customized using volumes or whatever a container orchestration solution provides.

For example, we will use a k8s ConfigMap to deploy etherpad on k8s.

## Proposal

- [x] remove development settings `COPY` statement from Docker image production stage