### PR TITLE
✨(plugins) add ep_lightship plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Implement application's health checks thanks to the ep_lightship plugin
+
 ## [1.8.0-education-1.1.0] - 2020-04-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -22,6 +22,23 @@ More commands are available, for reference, see:
 $ make help
 ```
 
+## Advanced configuration
+
+### Health checks
+
+Our docker image embeds the [lightship](https://github.com/gajus/lightship)
+application as an etherpad-lite plugin. It provides health check status
+endpoints to a running etherpad instance. The following environment variable
+can be injected in the container to configure its behavior:
+
+- `EP_LIGHTSHIP_DETECT_KUBERNETES`: a boolean-like string to choose whether
+  `lightship` should detect its environment and assign a random port to listen
+  to while not in k8s environment (default: `false`),
+
+- `EP_LIGHTSHIP_PORT`: the fixed port to listen to
+  (default: `9002`). Note that if `EP_LIGHTSHIP_DETECT_KUBERNETES` is `true`
+  and you are running in a non-k8s environment, this setting has no effect.
+
 ## Contributing
 
 This project is intended to be community-driven, so please, do not hesitate to

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,20 +25,22 @@ services:
       target: production
     image: etherpad:production
     environment:
-      DB_TYPE: postgres
-      DB_NAME: etherpad
-      DB_USER: foo
-      DB_PASS: pass
       DB_HOST: postgresql
+      DB_NAME: etherpad
+      DB_PASS: pass
       DB_PORT: 5432
-      SKIN_NAME: "education"
+      DB_TYPE: postgres
+      DB_USER: foo
       LOGLEVEL: "debug"
+      ROARR_LOG: "true"
+      SKIN_NAME: "education"
     user: "${DOCKER_USER:-1000}"
     volumes:
       - ./private/SESSIONKEY.txt:/app/SESSIONKEY.txt
       - ./private/APIKEY.txt:/app/APIKEY.txt
       # Custom plugins/skins development
       - ./src/static/skins/education:/app/src/static/skins/education
+      - ./src/plugins/ep_lightship:/app/node_modules/ep_lightship
       # Mount local settings for development
       - ./settings.json:/app/settings.json
     depends_on:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "author": "OpenFun",
   "license": "MIT",
   "dependencies": {
-    "ep_etherpad-lite": "file:src"
+    "ep_etherpad-lite": "file:src",
+    "ep_lightship": "file:src/plugins/ep_lightship"
   },
   "bugs": {
     "url": "https://github.com/openfun/etherpad-docker/issues"

--- a/src/plugins/ep_lightship/ep.json
+++ b/src/plugins/ep_lightship/ep.json
@@ -1,0 +1,10 @@
+{
+  "parts": [
+    {
+      "name": "serverStart",
+      "hooks": {
+        "expressCreateServer": "ep_lightship/server:start"
+      }
+    }
+  ]
+}

--- a/src/plugins/ep_lightship/package.json
+++ b/src/plugins/ep_lightship/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "ep_lightship",
+  "version": "0.1.0",
+  "description": "Etherpad-lite plugin that integrates lightship health checks",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "OpenFun",
+  "dependencies": {
+    "lightship": "6.1.0"
+  },
+  "license": "MIT"
+}

--- a/src/plugins/ep_lightship/server.js
+++ b/src/plugins/ep_lightship/server.js
@@ -1,0 +1,45 @@
+/*
+ * lightship health check status for etherpad-lite
+ *
+ * This plugin starts a webserver that accepts HTTP requests on a specific port
+ * to check the status of the etherpad-lite server. You can configure it's
+ * behavior by defining the following environment variables:
+ *
+ * EP_LIGHTSHIP_DETECT_KUBERNETES: should lightship detect its environment?
+ * i.e. local or k8s (default: false).
+ *
+ * EP_LIGHTSHIP_PORT: the lightship server port (default: 9002).
+ */
+
+const lightship = require('lightship');
+
+/* Etherpad-lite plugin hook function signature is expecting the following
+ * arguments:
+ *
+ *   - hook_name: the name of the called hook
+ *   - args: the execution context (depends on called hook)
+ *   - cb: hook callback function
+ *
+ * We are targetting the expressCreateServer hook that brings the following
+ * paremeters to the context:
+ *
+ *   - app: the main express application object
+ *   - server: the http server object
+ *
+ * For reference, see:
+ * https://etherpad.org/doc/v1.8.0-beta.1/#index_expresscreateserver
+ */
+exports.start = function(hook_name, args, cb) {
+  let ls = lightship.createLightship({
+    detectKubernetes: process.env.EP_LIGHTSHIP_DETECT_KUBERNETES === 'true',
+    port: process.env.EP_LIGHTSHIP_PORT || 9002,
+  });
+
+  ls.registerShutdownHandler(() => {
+    args.server.close();
+  });
+
+  // Lightship default state is "SERVER_IS_NOT_READY". Therefore, you must signal
+  // that the server is now ready to accept connections.
+  ls.signalReady();
+};


### PR DESCRIPTION
## Purpose

In a k8s context, an application needs relevant health check status endpoints for the readiness and liveness probes.

## Proposal

Current work integrates the [lightship](https://github.com/gajus/lightship) application as an etherpad-lite plugin using the `expressCreateServer` server hook.
