### PR TITLE
Improve build reproducibilty & fix project versioning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,24 +47,6 @@ jobs:
           command: |
             git whatchanged --name-only --pretty="" origin..HEAD | grep CHANGELOG
 
-  # Check lockfile consistency.
-  #
-  # Make sure that the package-lock.json file has been updated consequently to
-  # a package.json file.
-  check-lockfile:
-    docker:
-      - image: circleci/buildpack-deps:stretch
-    working_directory: ~/etherpad
-    steps:
-      # Checkout repository sources
-      - checkout
-      - run:
-          name: Check lockfile consistency
-          command: |
-            if git whatchanged --name-only --pretty="" origin..HEAD | grep package.json; then
-              git whatchanged --name-only --pretty="" origin..HEAD | grep package-lock.json
-            fi
-
   # Build the Docker image ready for production
   build:
     docker:
@@ -198,10 +180,6 @@ workflows:
             tags:
               only: /.*/
       - check-changelog:
-          filters:
-            tags:
-              only: /.*/
-      - check-lockfile:
           filters:
             tags:
               only: /.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Improve build reproducibility by using the `npm ci` command
+
 ## [1.8.0-education-1.2.0] - 2020-04-20
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,12 @@ RUN tar xzf epl.tgz --strip-components=1
 
 ENV NODE_ENV=production
 RUN cd src && \
-      npm install --no-progress --no-audit
+      npm ci
 
 # Install extra plugins
 COPY package.json package-lock.json /builder/
 COPY src/plugins /builder/src/plugins/
-RUN npm install --no-progress --no-audit
+RUN npm ci
 
 # Fake an installed node module
 RUN cd node_modules && \

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ default: help
 # -- Project
 package-lock.json: package.json
 	@echo "Updating package-lock.json file..."
-	@$(COMPOSE_RUN) -T --no-deps etherpad \
-	  cat package-lock.json > package-lock.json
+	@$(COMPOSE_RUN) --no-deps -u root etherpad \
+	  bash -c "npm install --no-progress --no-audit &> /dev/null && cat package-lock.json" > package-lock.json
 
 private/SESSIONKEY.txt:
 	mkdir -p private
@@ -67,7 +67,6 @@ clean: ## restore repository state as it was freshly cloned
 .PHONY: clean
 
 lockfile: \
-  build \
   package-lock.json
 lockfile: ## update npm package-lock.json file
 .PHONY: lockfile

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "etherpad-docker",
-  "version": "1.8.0",
+  "version": "1.2.0",
+  "ep_version": "1.8.0",
   "description": "A stateless Dockerfile for the etherpad-lite application.",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/static/skins/education/skin.json
+++ b/src/static/skins/education/skin.json
@@ -1,4 +1,4 @@
 {
   "name": "education",
-  "version": "1.2.0"
+  "version": "1.0.0"
 }


### PR DESCRIPTION
## Purpose

We recently proposed to switch to Yarn to ensure Docker builds reproducibility (see #14), but it looks like we've missed the `npm ci` command that precisely achieves was we need here, _i.e._ strictly respects the `package-lock.json` file to install dependencies and fails if this file (or the `package.json` file) requires an update. Plus, this command also fails if the `package.json` and `package-lock.json` files are not synced.

## Proposal

- [x] switch docker build to `npm ci`
- [x] update the `lockfile` Makefile rule

During this work, we've also fixed the project version number target so that all required information is in the `package.json` file.

Replace #14 