### PR TITLE
✨(skin) add terms link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improve build reproducibility by using the `npm ci` command
+- Upgrade education skin to 1.1.0 (add terms link)
 
 ## [1.8.0-education-1.2.0] - 2020-04-20
 

--- a/src/static/skins/education/index.css
+++ b/src/static/skins/education/index.css
@@ -18,6 +18,10 @@ body {
   background-size: cover;
 }
 
+a {
+  color: #f0f0f0;
+}
+
 #wrapper {
   border-top: none;
   margin-top: 0;
@@ -51,6 +55,10 @@ footer {
 
 footer img {
   max-width: 100px;
+}
+
+footer .terms {
+  padding-top: 1rem;
 }
 
 #inner {

--- a/src/static/skins/education/index.js
+++ b/src/static/skins/education/index.js
@@ -26,6 +26,14 @@ function customStart() {
   img.setAttribute('alt', 'pads for education icon');
   footer.appendChild(img);
 
+  let terms_wrapper = document.createElement('div');
+  terms_wrapper.setAttribute('class', 'terms');
+  let terms = document.createElement('a');
+  terms.setAttribute('href', '/terms');
+  terms.appendChild(document.createTextNode('Mentions légales'));
+  terms_wrapper.appendChild(terms);
+  footer.appendChild(terms_wrapper);
+
   /* layout */
   let wrapper = document.getElementById('wrapper');
   document.body.insertBefore(header, wrapper);

--- a/src/static/skins/education/skin.json
+++ b/src/static/skins/education/skin.json
@@ -1,4 +1,4 @@
 {
   "name": "education",
-  "version": "1.0.0"
+  "version": "1.1.0"
 }


### PR DESCRIPTION
## Purpose

Some instance requires a link to terms & condition in the pad home page.

## Proposal

Add a link to /terms in the home page. This page is supposed to be hosted by your web server acting as a reverse proxy for etherpad.