### PR TITLE
🐛(skin) fix education terms link

### DIFF
--- a/src/static/skins/education/index.js
+++ b/src/static/skins/education/index.js
@@ -29,7 +29,7 @@ function customStart() {
   let terms_wrapper = document.createElement('div');
   terms_wrapper.setAttribute('class', 'terms');
   let terms = document.createElement('a');
-  terms.setAttribute('href', '/terms');
+  terms.setAttribute('href', '/terms/');
   terms.appendChild(document.createTextNode('Mentions légales'));
   terms_wrapper.appendChild(terms);
   footer.appendChild(terms_wrapper);


### PR DESCRIPTION
## Purpose

The full target URL of the target page should contain a trailing slash.

## Proposal

Fix terms URL :sweat_smile: 