### PR TITLE
🔖(minor) bump to 1.8.0-education-1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0-education-1.3.0] - 2020-04-24
+
 ### Changed
 
 - Improve build reproducibility by using the `npm ci` command
@@ -42,7 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New 1.8.0 official release
 
-[unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.8.0+education-1.2.0...HEAD
+[unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.8.0+education-1.3.0...HEAD
+[1.8.0-education-1.3.0]: https://github.com/openfun/etherpad-docker/compare/v1.8.0+education-1.2.0...v1.8.0+education-1.3.0
 [1.8.0-education-1.2.0]: https://github.com/openfun/etherpad-docker/compare/v1.8.0+education-1.1.0...v1.8.0+education-1.2.0
 [1.8.0-education-1.1.0]: https://github.com/openfun/etherpad-docker/compare/v1.8.0+education-1.0.0...v1.8.0+education-1.1.0
 [1.8.0-education-1.0.0]: https://github.com/openfun/etherpad-docker/compare/v1.8.0...v1.8.0+education-1.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "etherpad-docker",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "ep_version": "1.8.0",
   "description": "A stateless Dockerfile for the etherpad-lite application.",
   "scripts": {


### PR DESCRIPTION
### Changed

- Improve build reproducibility by using the `npm ci` command
- Upgrade education skin to 1.1.0 (add terms link)